### PR TITLE
Match macOS popup styling to Windows UI

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/App.axaml
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/App.axaml
@@ -20,11 +20,13 @@
         </Style>
 
         <Style Selector="TextBox">
-            <Setter Property="Padding" Value="4,6" />
+            <Setter Property="Padding" Value="4,5" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="CaretBrush" Value="{DynamicResource ForegroundBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}" />
+            <Setter Property="FocusAdorner" Value="{x:Null}" />
+            <Setter Property="SelectionBrush" Value="#334cc2ff" />
         </Style>
 
         <Style Selector="Button">
@@ -51,16 +53,6 @@
         <Style Selector="ListBox">
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Background" Value="Transparent" />
-        </Style>
-
-        <Style Selector="ListBoxItem">
-            <Setter Property="Padding" Value="4,2,2,2" />
-        </Style>
-        <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource HoverBrush}" />
-        </Style>
-        <Style Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource ActiveBrush}" />
         </Style>
     </Application.Styles>
 </Application>

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/App.axaml
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/App.axaml
@@ -25,7 +25,6 @@
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="CaretBrush" Value="{DynamicResource ForegroundBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}" />
-            <Setter Property="FocusAdorner" Value="{x:Null}" />
             <Setter Property="SelectionBrush" Value="#334cc2ff" />
         </Style>
 

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/MainWindow.axaml
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/MainWindow.axaml
@@ -63,17 +63,7 @@
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="Background" Value="Transparent" />
         </Style>
-        <Style Selector="TextBox#SearchText:focus /template/ Border">
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="Background" Value="Transparent" />
-        </Style>
-        <Style Selector="TextBox#SearchText:focus-within /template/ Border">
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="Background" Value="Transparent" />
-        </Style>
-        <Style Selector="TextBox#SearchText:focus-visible /template/ Border">
+        <Style Selector="TextBox#SearchText:focus /template/ Border, TextBox#SearchText:focus-within /template/ Border, TextBox#SearchText:focus-visible /template/ Border">
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="Background" Value="Transparent" />

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/MainWindow.axaml
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/MainWindow.axaml
@@ -13,15 +13,79 @@
         <controls:ArrayLastItemConverter x:Key="ArrayLastItemConverter" />
         <controls:BoolToObjectConverter x:Key="TrueToVisibleConverter" TrueValue="True" FalseValue="False" />
         <controls:NumberCompareConverter x:Key="ZeroToCollapsedConverter" EdgeValue="0" EqualValue="False" GreaterValue="True" />
-        <controls:BoolToObjectConverter x:Key="TrueToAccentColorConverter">
-            <controls:BoolToObjectConverter.TrueValue>
-                <SolidColorBrush Color="#4cc2ff" />
-            </controls:BoolToObjectConverter.TrueValue>
-            <controls:BoolToObjectConverter.FalseValue>
-                <SolidColorBrush Color="Transparent" />
-            </controls:BoolToObjectConverter.FalseValue>
-        </controls:BoolToObjectConverter>
+        <StreamGeometry x:Key="SearchIconGeometry">M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16a6.471 6.471 0 0 0 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z</StreamGeometry>
+        <StreamGeometry x:Key="CopyIconGeometry">M16 1H4C2.9 1 2 1.9 2 3v12h2V3h12V1zm3 4H8C6.9 5 6 5.9 6 7v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z</StreamGeometry>
+        <ControlTheme x:Key="SnippetListBoxItemTheme" TargetType="ListBoxItem">
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Name="ItemBorder" CornerRadius="2" Background="Transparent">
+                        <Grid>
+                            <Border Name="SelectionStripe"
+                                    Width="2"
+                                    Height="20"
+                                    CornerRadius="1"
+                                    Background="Transparent"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center" />
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Margin="4,2,2,2"
+                                              Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#ItemBorder">
+                <Setter Property="Background" Value="{DynamicResource HoverBrush}" />
+            </Style>
+            <Style Selector="^:selected /template/ Border#ItemBorder">
+                <Setter Property="Background" Value="{DynamicResource ActiveBrush}" />
+            </Style>
+            <Style Selector="^:selected /template/ Border#SelectionStripe">
+                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+            </Style>
+        </ControlTheme>
     </Window.Resources>
+
+    <Window.Styles>
+        <Style Selector="TextBox#SearchText /template/ Border">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="TextBox#SearchText /template/ Border#PART_BorderElement">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="TextBox#SearchText:focus /template/ Border">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="TextBox#SearchText:focus-within /template/ Border">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="TextBox#SearchText:focus-visible /template/ Border">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="TextBox#SearchText /template/ ScrollViewer#PART_ScrollViewer">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="TextBox#SearchText /template/ TextPresenter#PART_TextPresenter">
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </Window.Styles>
 
     <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource InactiveBrush}"
             BorderThickness="1" CornerRadius="4" Padding="0">
@@ -45,13 +109,37 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
-                <Grid>
-                    <TextBlock Text="🔍" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,8,0" />
-                    <TextBlock Text="Search..." VerticalAlignment="Center" Margin="6,0,0,0"
-                               IsVisible="{Binding Text, ElementName=SearchText, Converter={StaticResource StringEmptyToVisible}}"
-                               FontSize="14" Opacity=".5" IsHitTestVisible="False" />
-                    <TextBox x:Name="SearchText" FontSize="14" />
-                </Grid>
+                <Border Background="{DynamicResource TextBoxBackgroundBrush}"
+                        BorderBrush="Transparent"
+                        BorderThickness="0"
+                        CornerRadius="0"
+                        Height="30">
+                    <Grid>
+                        <Viewbox Width="13" Height="13"
+                                 HorizontalAlignment="Right"
+                                 VerticalAlignment="Center"
+                                 Margin="0,0,7,0">
+                            <Path Data="{StaticResource SearchIconGeometry}"
+                                  Fill="{DynamicResource GrayBrush}" />
+                        </Viewbox>
+                        <TextBlock Text="Search..."
+                                   VerticalAlignment="Center"
+                                   Margin="6,0,24,0"
+                                   IsVisible="{Binding Text, ElementName=SearchText, Converter={StaticResource StringEmptyToVisible}}"
+                                   FontSize="14"
+                                   Opacity=".5"
+                                   IsHitTestVisible="False" />
+                        <TextBox x:Name="SearchText"
+                                 FontSize="14"
+                                 MinHeight="0"
+                                 Height="28"
+                                 FocusAdorner="{x:Null}"
+                                 Background="Transparent"
+                                 BorderThickness="0"
+                                 VerticalContentAlignment="Center"
+                                 Padding="6,0,24,1" />
+                    </Grid>
+                </Border>
             </StackPanel>
 
             <Border BorderThickness="0,1,0,0" BorderBrush="{DynamicResource ActiveBrush}" Grid.Row="1"
@@ -62,16 +150,43 @@
 
             <ListBox x:Name="ListBox" ItemsSource="{Binding Snippets}" SelectedIndex="0"
                      BorderThickness="0" Margin="4" Grid.Row="2"
+                     ItemContainerTheme="{StaticResource SnippetListBoxItemTheme}"
                      IsVisible="{Binding Snippets.Count, Converter={StaticResource ZeroToCollapsedConverter}}"
                      MaxHeight="400"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <Border Padding="4">
-                            <StackPanel>
-                                <TextBlock Text="{Binding Title}" MaxHeight="16" />
-                                <TextBlock Text="{Binding Description}" FontSize="11" Opacity=".3" />
-                            </StackPanel>
+                            <Grid>
+                                <StackPanel>
+                                    <TextBlock Height="16" TextTrimming="CharacterEllipsis">
+                                        <TextBlock.Text>
+                                            <MultiBinding Converter="{StaticResource SnippetPathJoinConverter}">
+                                                <Binding Path="Path" />
+                                                <Binding Path="DataContext.Selected.Count"
+                                                         RelativeSource="{RelativeSource AncestorType=ListBox}" />
+                                            </MultiBinding>
+                                        </TextBlock.Text>
+                                    </TextBlock>
+                                    <TextBlock Text="{Binding Description}"
+                                               FontSize="11"
+                                               Opacity=".3"
+                                               TextTrimming="CharacterEllipsis" />
+                                </StackPanel>
+
+                                <Button Classes="plain"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center"
+                                        ToolTip.Tip="Copy snippet to the clipboard (Ctrl+C)"
+                                        Command="{Binding DataContext.Copy, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding}"
+                                        IsVisible="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}, Converter={StaticResource TrueToVisibleConverter}}">
+                                    <Viewbox Width="14" Height="14">
+                                        <Path Data="{StaticResource CopyIconGeometry}"
+                                              Fill="{DynamicResource ForegroundBrush}" />
+                                    </Viewbox>
+                                </Button>
+                            </Grid>
                         </Border>
                     </DataTemplate>
                 </ListBox.ItemTemplate>

--- a/src/Neptuo.Productivity.SnippetManager/ViewModels/Commands/UseSnippetCommand.cs
+++ b/src/Neptuo.Productivity.SnippetManager/ViewModels/Commands/UseSnippetCommand.cs
@@ -6,6 +6,6 @@ namespace Neptuo.Productivity.SnippetManager.ViewModels.Commands
     public abstract class UseSnippetCommand : Command<SnippetModel>
     {
         public override bool CanExecute(SnippetModel parameter) 
-            => parameter.IsFilled;
+            => parameter != null && parameter.IsFilled;
     }
 }

--- a/test/Neptuo.Productivity.SnippetManager.Tests/CopySnippetCommandTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/CopySnippetCommandTests.cs
@@ -5,7 +5,7 @@ using Neptuo.Productivity.SnippetManager.ViewModels.Commands;
 
 namespace Neptuo.Productivity.SnippetManager.Tests;
 
-public class UseSnippetCommandTests
+public class CopySnippetCommandTests
 {
     [Fact]
     public void CopyCommand_CanExecute_ReturnsFalseForNullParameter()

--- a/test/Neptuo.Productivity.SnippetManager.Tests/UseSnippetCommandTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/UseSnippetCommandTests.cs
@@ -1,0 +1,45 @@
+using System.Windows.Input;
+using Neptuo.Productivity.SnippetManager.Models;
+using Neptuo.Productivity.SnippetManager.Services;
+using Neptuo.Productivity.SnippetManager.ViewModels.Commands;
+
+namespace Neptuo.Productivity.SnippetManager.Tests;
+
+public class UseSnippetCommandTests
+{
+    [Fact]
+    public void CopyCommand_CanExecute_ReturnsFalseForNullParameter()
+    {
+        ICommand command = new CopySnippetCommand(new TestClipboardService());
+
+        bool canExecute = command.CanExecute(null);
+
+        Assert.False(canExecute);
+    }
+
+    [Fact]
+    public void CopyCommand_CanExecute_ReturnsFalseForShadowSnippet()
+    {
+        var command = new CopySnippetCommand(new TestClipboardService());
+
+        bool canExecute = command.CanExecute(new SnippetModel("GitHub"));
+
+        Assert.False(canExecute);
+    }
+
+    [Fact]
+    public void CopyCommand_CanExecute_ReturnsTrueForFilledSnippet()
+    {
+        var command = new CopySnippetCommand(new TestClipboardService());
+
+        bool canExecute = command.CanExecute(new SnippetModel("GitHub - dotnet", "https://github.com/dotnet"));
+
+        Assert.True(canExecute);
+    }
+
+    private sealed class TestClipboardService : IClipboardService
+    {
+        public void SetText(string text)
+        { }
+    }
+}


### PR DESCRIPTION
This brings the Avalonia snippet popup closer to the Windows UI so the macOS port feels consistent instead of obviously Fluent-styled. While tightening the popup styling, it also fixes a null `CanExecute` crash triggered when Avalonia recycles list items during search updates.

## What changed

- restyled the search area to remove Fluent focus and border chrome and match the flatter Windows search box more closely
- replaced the default `ListBoxItem` visuals with a popup-specific container theme that uses a dark selected row, a thin accent stripe, and a selection-only copy affordance
- tightened the popup text spacing and alignment so the macOS layout better matches the Windows screenshot
- made `UseSnippetCommand.CanExecute` null-safe and added regression coverage for null, shadow, and filled snippets

## Notes for reviewers

- The search box tweaks are intentionally scoped to `SearchText` and target Fluent template parts instead of replacing the entire `TextBox` template.
- The list item styling is also scoped to the snippet popup so the rest of the Avalonia UI keeps its default theme behavior.

## Screenshot

_Rendered from the current Avalonia popup state used for the styling work._

![Avalonia popup screenshot](https://github.com/user-attachments/assets/03a89a63-5461-41d7-b018-d993e9c20295)