### PR TITLE
Use Command shortcuts for Avalonia on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once you have the configuration file, the app will monitor changes and prompt yo
 
 ### General
 
-Enables you to define your own global hotkey for opening snippet list. Default is `Ctrl+Shift+V`.
+Enables you to define your own global hotkey for opening snippet list. Default is `Ctrl+Shift+V` on Windows/Linux and `Cmd+Shift+V` on macOS.
 
 ### Clipboard
 

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/App.axaml.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/App.axaml.cs
@@ -116,7 +116,7 @@ public partial class App : Application
     }
 
     private string GetCurrentHotkey()
-        => configuration.General?.HotKey ?? GeneralConfiguration.Example.HotKey ?? "Control+Shift+V";
+        => configuration.General?.HotKey ?? GeneralConfiguration.DefaultHotKey;
 
     private Configuration CreateConfiguration()
     {

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Hotkey.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Hotkey.cs
@@ -12,13 +12,15 @@ public class Hotkey : IDisposable
 
     public void Bind(Navigator navigator, string? rawHotkey)
     {
-        DiagnosticsLog.Info($"Binding global hotkey. Configured value: '{rawHotkey ?? "Control+Shift+V (default)"}'.");
+        string effectiveHotkey = string.IsNullOrWhiteSpace(rawHotkey)
+            ? GeneralConfiguration.DefaultHotKey
+            : rawHotkey;
+        string sourceSuffix = string.IsNullOrWhiteSpace(rawHotkey) ? " (default)" : string.Empty;
+        DiagnosticsLog.Info($"Binding global hotkey. Configured value: '{effectiveHotkey}{sourceSuffix}'.");
 
-        var key = KeyCode.VcV;
-        var modifiers = ModifierMask.Ctrl | ModifierMask.Shift;
-        if (!string.IsNullOrEmpty(rawHotkey) && !TryParseHotKey(rawHotkey, out key, out modifiers))
+        if (!TryParseHotKey(effectiveHotkey, out var key, out var modifiers))
         {
-            DiagnosticsLog.Error($"Unable to parse configured global hotkey '{rawHotkey}'.");
+            DiagnosticsLog.Error($"Unable to parse configured global hotkey '{effectiveHotkey}'.");
             navigator.Shutdown();
             return;
         }

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Hotkey.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Hotkey.cs
@@ -16,7 +16,7 @@ public class Hotkey : IDisposable
             ? GeneralConfiguration.DefaultHotKey
             : rawHotkey;
         string sourceSuffix = string.IsNullOrWhiteSpace(rawHotkey) ? " (default)" : string.Empty;
-        DiagnosticsLog.Info($"Binding global hotkey. Configured value: '{effectiveHotkey}{sourceSuffix}'.");
+        DiagnosticsLog.Info($"Binding global hotkey. Effective value: '{effectiveHotkey}{sourceSuffix}'.");
 
         if (!TryParseHotKey(effectiveHotkey, out var key, out var modifiers))
         {

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/HelpWindow.axaml
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/HelpWindow.axaml
@@ -8,7 +8,7 @@
         <Grid Margin="0,8,0,0" RowDefinitions="Auto,Auto">
             <StackPanel Orientation="Vertical" Grid.Row="0">
                 <TextBlock Margin="0,5,0,0" x:Name="tblVersion" Text="v1.8.0" />
-                <TextBlock Margin="0,8,0,0" x:Name="tblHotkey" Text="Global hotkey: Control+Shift+V" />
+                <TextBlock Margin="0,8,0,0" x:Name="tblHotkey" Text="Global hotkey:" />
                 <TextBlock Margin="0,4,0,0" MaxWidth="460" TextWrapping="Wrap"
                            Text="On macOS, global hotkeys and automatic paste require Accessibility permission for the app or the terminal/IDE hosting it." />
                 <TextBlock Margin="0,4,0,0" MaxWidth="460" TextWrapping="Wrap"

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/HelpWindow.axaml.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/HelpWindow.axaml.cs
@@ -10,6 +10,7 @@ public partial class HelpWindow : Window
     public HelpWindow()
     {
         InitializeComponent();
+        SetHotkey(GeneralConfiguration.DefaultHotKey);
     }
 
     public HelpWindow(Navigator navigator) : this()

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Views/MainWindow.axaml.cs
@@ -100,7 +100,7 @@ public partial class MainWindow : Window
             UseSelectedSnippet(ViewModel.Apply);
             e.Handled = true;
         }
-        else if (e.Key == Key.C && (e.KeyModifiers & KeyModifiers.Control) != 0)
+        else if (IsCopyShortcutGesture(e.Key, e.KeyModifiers))
         {
             UseSelectedSnippet(ViewModel.Copy);
             e.Handled = true;
@@ -135,6 +135,18 @@ public partial class MainWindow : Window
         }
 
         return false;
+    }
+
+    internal static bool IsCopyShortcutGesture(Key key, KeyModifiers modifiers)
+    {
+        if (key != Key.C)
+            return false;
+
+        KeyModifiers expectedModifier = OperatingSystem.IsMacOS()
+            ? KeyModifiers.Meta
+            : KeyModifiers.Control;
+
+        return (modifiers & expectedModifier) != 0;
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/src/Neptuo.Productivity.SnippetManager/GeneralConfiguration.cs
+++ b/src/Neptuo.Productivity.SnippetManager/GeneralConfiguration.cs
@@ -2,11 +2,11 @@ namespace Neptuo.Productivity.SnippetManager;
 
 public class GeneralConfiguration
 {
-    public const string WindowsDefaultHotKey = "Control+Shift+V";
+    public const string NonMacDefaultHotKey = "Control+Shift+V";
     public const string MacDefaultHotKey = "Command+Shift+V";
 
     public static string DefaultHotKey
-        => OperatingSystem.IsMacOS() ? MacDefaultHotKey : WindowsDefaultHotKey;
+        => OperatingSystem.IsMacOS() ? MacDefaultHotKey : NonMacDefaultHotKey;
 
     public string? HotKey { get; set; }
 

--- a/src/Neptuo.Productivity.SnippetManager/GeneralConfiguration.cs
+++ b/src/Neptuo.Productivity.SnippetManager/GeneralConfiguration.cs
@@ -2,10 +2,17 @@ namespace Neptuo.Productivity.SnippetManager;
 
 public class GeneralConfiguration
 {
+    public const string WindowsDefaultHotKey = "Control+Shift+V";
+    public const string MacDefaultHotKey = "Command+Shift+V";
+
+    public static string DefaultHotKey
+        => OperatingSystem.IsMacOS() ? MacDefaultHotKey : WindowsDefaultHotKey;
+
     public string? HotKey { get; set; }
 
-    public static GeneralConfiguration Example = new GeneralConfiguration()
-    {
-        HotKey = "Control+Shift+V"
-    };
+    public static GeneralConfiguration Example
+        => new()
+        {
+            HotKey = DefaultHotKey
+        };
 }

--- a/test/Neptuo.Productivity.SnippetManager.Tests/GeneralConfigurationTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/GeneralConfigurationTests.cs
@@ -1,0 +1,18 @@
+namespace Neptuo.Productivity.SnippetManager.Tests;
+
+public class GeneralConfigurationTests
+{
+    [Fact]
+    public void DefaultHotKey_UsesThePlatformSpecificShortcut()
+    {
+        string expected = OperatingSystem.IsMacOS()
+            ? GeneralConfiguration.MacDefaultHotKey
+            : GeneralConfiguration.WindowsDefaultHotKey;
+
+        Assert.Equal(expected, GeneralConfiguration.DefaultHotKey);
+    }
+
+    [Fact]
+    public void Example_UsesTheDefaultHotKey()
+        => Assert.Equal(GeneralConfiguration.DefaultHotKey, GeneralConfiguration.Example.HotKey);
+}

--- a/test/Neptuo.Productivity.SnippetManager.Tests/GeneralConfigurationTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/GeneralConfigurationTests.cs
@@ -3,13 +3,12 @@ namespace Neptuo.Productivity.SnippetManager.Tests;
 public class GeneralConfigurationTests
 {
     [Fact]
-    public void DefaultHotKey_UsesThePlatformSpecificShortcut()
+    public void DefaultHotKey_IsOneOfTheSupportedPlatformDefaults()
     {
-        string expected = OperatingSystem.IsMacOS()
-            ? GeneralConfiguration.MacDefaultHotKey
-            : GeneralConfiguration.WindowsDefaultHotKey;
-
-        Assert.Equal(expected, GeneralConfiguration.DefaultHotKey);
+        Assert.Contains(
+            GeneralConfiguration.DefaultHotKey,
+            new[] { GeneralConfiguration.MacDefaultHotKey, GeneralConfiguration.NonMacDefaultHotKey }
+        );
     }
 
     [Fact]

--- a/test/Neptuo.Productivity.SnippetManager.Tests/HotkeyTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/HotkeyTests.cs
@@ -29,16 +29,26 @@ public class HotkeyTests
     }
 
     [Fact]
-    public void IsCopyShortcutGesture_UsesPlatformSpecificModifier()
+    public void IsCopyShortcutGesture_MatchesPlatformModifier()
     {
         KeyModifiers expectedModifier = OperatingSystem.IsMacOS()
             ? KeyModifiers.Meta
             : KeyModifiers.Control;
-        KeyModifiers unexpectedModifier = OperatingSystem.IsMacOS()
+
+        Assert.True(MainWindow.IsCopyShortcutGesture(Key.C, expectedModifier));
+    }
+
+    [Fact]
+    public void IsCopyShortcutGesture_RejectsWrongKey()
+        => Assert.False(MainWindow.IsCopyShortcutGesture(Key.V, KeyModifiers.Control | KeyModifiers.Meta));
+
+    [Fact]
+    public void IsCopyShortcutGesture_RejectsOppositeModifier()
+    {
+        KeyModifiers wrongModifier = OperatingSystem.IsMacOS()
             ? KeyModifiers.Control
             : KeyModifiers.Meta;
 
-        Assert.True(MainWindow.IsCopyShortcutGesture(Key.C, expectedModifier));
-        Assert.False(MainWindow.IsCopyShortcutGesture(Key.C, unexpectedModifier));
+        Assert.False(MainWindow.IsCopyShortcutGesture(Key.C, wrongModifier));
     }
 }

--- a/test/Neptuo.Productivity.SnippetManager.Tests/HotkeyTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/HotkeyTests.cs
@@ -1,4 +1,6 @@
 using SharpHook.Native;
+using Avalonia.Input;
+using Neptuo.Productivity.SnippetManager.Views;
 
 namespace Neptuo.Productivity.SnippetManager.Tests;
 
@@ -24,5 +26,19 @@ public class HotkeyTests
         bool result = Hotkey.MatchesModifiers(currentModifiers, expectedModifiers);
 
         Assert.False(result);
+    }
+
+    [Fact]
+    public void IsCopyShortcutGesture_UsesPlatformSpecificModifier()
+    {
+        KeyModifiers expectedModifier = OperatingSystem.IsMacOS()
+            ? KeyModifiers.Meta
+            : KeyModifiers.Control;
+        KeyModifiers unexpectedModifier = OperatingSystem.IsMacOS()
+            ? KeyModifiers.Control
+            : KeyModifiers.Meta;
+
+        Assert.True(MainWindow.IsCopyShortcutGesture(Key.C, expectedModifier));
+        Assert.False(MainWindow.IsCopyShortcutGesture(Key.C, unexpectedModifier));
     }
 }


### PR DESCRIPTION
macOS users expect Command-based shortcuts, but the Avalonia app still defaulted to Control-based ones. This aligns the app with native macOS behavior while leaving other platforms unchanged.

### What changed
- switch the default global hotkey on macOS from `Control+Shift+V` to `Command+Shift+V`
- use `Command+C` for copying the selected snippet in the Avalonia UI on macOS
- keep existing Windows/Linux shortcut behavior as-is
- update help/documentation text and add coverage for the platform-specific shortcut logic

No migration is needed: explicitly configured shortcuts still take precedence over the defaults.