### PR TITLE
Print .app bundle path in terminal logger after publish

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Neptuo.Productivity.SnippetManager.Avalonia.Publish.targets
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Neptuo.Productivity.SnippetManager.Avalonia.Publish.targets
@@ -146,8 +146,7 @@
     <Exec Command="chmod +x &quot;$(_MacAppBundleExecutablePath)&quot;"
           Condition="'$(OS)' != 'Windows_NT' and Exists('$(_MacAppBundleExecutablePath)')" />
 
-    <Message Importance="high"
-             Text="Created macOS app bundle at '$(_MacAppBundleDir)'." />
+    <Exec Command="echo Created macOS app bundle at '$(_MacAppBundleDir)'" />
   </Target>
 
 </Project>

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Neptuo.Productivity.SnippetManager.Avalonia.Publish.targets
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Neptuo.Productivity.SnippetManager.Avalonia.Publish.targets
@@ -15,8 +15,8 @@
           AfterTargets="Publish"
           Condition="'$(CreateMacAppBundle)' == 'true' and '$(_IsMacAppBundleRuntime)' == 'true'">
     <PropertyGroup>
-      <_MacAppBundleDir Condition="'$(MacAppBundleDir)' != ''">$([System.IO.Path]::GetFullPath('$(MacAppBundleDir)'))</_MacAppBundleDir>
-      <_MacAppBundleDir Condition="'$(_MacAppBundleDir)' == ''">$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(PublishDir)', '$(MacAppBundleName).app'))))</_MacAppBundleDir>
+      <_MacAppBundleDir Condition="'$(MacAppBundleDir)' != ''">$([MSBuild]::NormalizePath('$(MacAppBundleDir)'))</_MacAppBundleDir>
+      <_MacAppBundleDir Condition="'$(_MacAppBundleDir)' == ''">$([MSBuild]::NormalizePath('$(PublishDir)', '$(MacAppBundleName).app'))</_MacAppBundleDir>
       <_MacAppBundleContentsDir>$([System.IO.Path]::Combine('$(_MacAppBundleDir)', 'Contents'))</_MacAppBundleContentsDir>
       <_MacAppBundleMacOSDir>$([System.IO.Path]::Combine('$(_MacAppBundleContentsDir)', 'MacOS'))</_MacAppBundleMacOSDir>
       <_MacAppBundleResourcesDir>$([System.IO.Path]::Combine('$(_MacAppBundleContentsDir)', 'Resources'))</_MacAppBundleResourcesDir>

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Neptuo.Productivity.SnippetManager.Avalonia.Publish.targets
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Neptuo.Productivity.SnippetManager.Avalonia.Publish.targets
@@ -146,7 +146,8 @@
     <Exec Command="chmod +x &quot;$(_MacAppBundleExecutablePath)&quot;"
           Condition="'$(OS)' != 'Windows_NT' and Exists('$(_MacAppBundleExecutablePath)')" />
 
-    <Exec Command="echo Created macOS app bundle at '$(_MacAppBundleDir)'" />
+    <Message Importance="high"
+             Text="$(MSBuildProjectName) -> $(_MacAppBundleDir)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
After `dotnet publish` with `CreateMacAppBundle=true`, the terminal logger summary line shows the default publish directory (e.g. `artifacts/`) rather than the created `.app` bundle path. This makes it hard to find where the bundle was placed.

This PR updates the `CreateMacAppBundle` target to emit its output in the `<ProjectName> -> <path>` format that the .NET CLI terminal logger recognizes. This overrides the default publish directory display so the summary line shows the `.app` bundle path instead:

```
Neptuo.Productivity.SnippetManager.Avalonia net9.0 osx-arm64 succeeded (10,8s) → artifacts/SnippetManager.app
```

Also switches path resolution from `System.IO.Path.GetFullPath` (resolves relative to `Environment.CurrentDirectory`) to `$([MSBuild]::NormalizePath())` (resolves relative to the project directory) for correctness when `dotnet publish` is invoked from outside the project directory.