### PR TITLE
Fix window positioning for Chromium address bar on macOS

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSTextAnchor.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSTextAnchor.cs
@@ -85,7 +85,8 @@ internal static class MacOSTextAnchor
                 bounds = ToPixelRect(selectedRangeRect);
                 DiagnosticsLog.Info($"Resolved macOS selected text bounds to {FormatPixelRect(bounds)}.");
 
-                if (!IsSelectedTextBoundsPlausible(bounds))
+                PixelRect? screenBounds = TryGetDisplayBoundsForPoint(bounds);
+                if (!IsSelectedTextBoundsPlausible(bounds, screenBounds))
                 {
                     DiagnosticsLog.Info($"Rejected macOS selected text bounds {FormatPixelRect(bounds)} as implausible (degenerate size at screen edge). Falling back to alternative anchoring.");
                     bounds = default;
@@ -97,7 +98,7 @@ internal static class MacOSTextAnchor
         }
     }
 
-    internal static bool IsSelectedTextBoundsPlausible(PixelRect bounds)
+    internal static bool IsSelectedTextBoundsPlausible(PixelRect bounds, PixelRect? screenBounds)
     {
         if (bounds.Width > 1 || bounds.Height > 1)
             return true;
@@ -105,27 +106,37 @@ internal static class MacOSTextAnchor
         // A 1×1 (or smaller) rect is only suspicious when it sits at a screen edge,
         // which indicates the application returned a degenerate placeholder rather than
         // a real caret position (observed with Chromium-based browsers' address bar).
-        if (bounds.X <= 0 || bounds.Y <= 0)
+        if (screenBounds is not PixelRect screen)
+            return true;
+
+        if (bounds.X <= screen.X || bounds.Y <= screen.Y)
             return false;
 
-        if (OperatingSystem.IsMacOS())
-        {
-            try
-            {
-                uint displayId = NativeMethods.CGMainDisplayID();
-                int displayWidth = (int)NativeMethods.CGDisplayPixelsWide(displayId);
-                int displayHeight = (int)NativeMethods.CGDisplayPixelsHigh(displayId);
-
-                if (bounds.X + bounds.Width >= displayWidth || bounds.Y + bounds.Height >= displayHeight)
-                    return false;
-            }
-            catch
-            {
-                // If we can't query display dimensions, accept the bounds.
-            }
-        }
+        if (bounds.X + bounds.Width >= screen.X + screen.Width || bounds.Y + bounds.Height >= screen.Y + screen.Height)
+            return false;
 
         return true;
+    }
+
+    private static PixelRect? TryGetDisplayBoundsForPoint(PixelRect bounds)
+    {
+        if (!OperatingSystem.IsMacOS())
+            return null;
+
+        try
+        {
+            var point = new CGPoint { X = bounds.X + bounds.Width / 2.0, Y = bounds.Y + bounds.Height / 2.0 };
+            int error = NativeMethods.CGGetDisplaysWithPoint(point, 1, out uint displayId, out uint matchingCount);
+            if (error != 0 || matchingCount == 0)
+                return null;
+
+            CGRect displayRect = NativeMethods.CGDisplayBounds(displayId);
+            return ToPixelRect(displayRect);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static bool TryGetElementBounds(CFObjectHandle element, out PixelRect bounds)
@@ -396,12 +407,9 @@ internal static class MacOSTextAnchor
         private const string CoreGraphicsLib = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
 
         [DllImport(CoreGraphicsLib)]
-        internal static extern uint CGMainDisplayID();
+        internal static extern int CGGetDisplaysWithPoint(CGPoint point, uint maxDisplays, out uint display, out uint matchingDisplayCount);
 
         [DllImport(CoreGraphicsLib)]
-        internal static extern nuint CGDisplayPixelsWide(uint display);
-
-        [DllImport(CoreGraphicsLib)]
-        internal static extern nuint CGDisplayPixelsHigh(uint display);
+        internal static extern CGRect CGDisplayBounds(uint display);
     }
 }

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSTextAnchor.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSTextAnchor.cs
@@ -84,9 +84,48 @@ internal static class MacOSTextAnchor
 
                 bounds = ToPixelRect(selectedRangeRect);
                 DiagnosticsLog.Info($"Resolved macOS selected text bounds to {FormatPixelRect(bounds)}.");
+
+                if (!IsSelectedTextBoundsPlausible(bounds))
+                {
+                    DiagnosticsLog.Info($"Rejected macOS selected text bounds {FormatPixelRect(bounds)} as implausible (degenerate size at screen edge). Falling back to alternative anchoring.");
+                    bounds = default;
+                    return false;
+                }
+
                 return true;
             }
         }
+    }
+
+    internal static bool IsSelectedTextBoundsPlausible(PixelRect bounds)
+    {
+        if (bounds.Width > 1 || bounds.Height > 1)
+            return true;
+
+        // A 1×1 (or smaller) rect is only suspicious when it sits at a screen edge,
+        // which indicates the application returned a degenerate placeholder rather than
+        // a real caret position (observed with Chromium-based browsers' address bar).
+        if (bounds.X <= 0 || bounds.Y <= 0)
+            return false;
+
+        if (OperatingSystem.IsMacOS())
+        {
+            try
+            {
+                uint displayId = NativeMethods.CGMainDisplayID();
+                int displayWidth = (int)NativeMethods.CGDisplayPixelsWide(displayId);
+                int displayHeight = (int)NativeMethods.CGDisplayPixelsHigh(displayId);
+
+                if (bounds.X + bounds.Width >= displayWidth || bounds.Y + bounds.Height >= displayHeight)
+                    return false;
+            }
+            catch
+            {
+                // If we can't query display dimensions, accept the bounds.
+            }
+        }
+
+        return true;
     }
 
     private static bool TryGetElementBounds(CFObjectHandle element, out PixelRect bounds)
@@ -353,5 +392,16 @@ internal static class MacOSTextAnchor
 
         [DllImport(CoreFoundationLib)]
         internal static extern void CFRelease(IntPtr value);
+
+        private const string CoreGraphicsLib = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
+
+        [DllImport(CoreGraphicsLib)]
+        internal static extern uint CGMainDisplayID();
+
+        [DllImport(CoreGraphicsLib)]
+        internal static extern nuint CGDisplayPixelsWide(uint display);
+
+        [DllImport(CoreGraphicsLib)]
+        internal static extern nuint CGDisplayPixelsHigh(uint display);
     }
 }

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/WindowPositioning.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/WindowPositioning.cs
@@ -22,11 +22,15 @@ internal static class WindowPositioning
 
         int x = anchorRight + normalizedWidth <= workingAreaRight
             ? anchorRight
-            : resolvedAnchor.Bounds.X - normalizedWidth;
+            : resolvedAnchor.Bounds.X - normalizedWidth >= workingArea.X
+                ? resolvedAnchor.Bounds.X - normalizedWidth
+                : resolvedAnchor.Bounds.X;
 
         int y = anchorBottom + normalizedHeight <= workingAreaBottom
             ? anchorBottom
-            : resolvedAnchor.Bounds.Y - normalizedHeight;
+            : resolvedAnchor.Bounds.Y - normalizedHeight >= workingArea.Y
+                ? resolvedAnchor.Bounds.Y - normalizedHeight
+                : resolvedAnchor.Bounds.Y;
 
         x = Clamp(x, workingArea.X, workingAreaRight - normalizedWidth);
         y = Clamp(y, workingArea.Y, workingAreaBottom - normalizedHeight);

--- a/test/Neptuo.Productivity.SnippetManager.Tests/SelectedTextBoundsPlausibilityTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/SelectedTextBoundsPlausibilityTests.cs
@@ -4,13 +4,17 @@ namespace Neptuo.Productivity.SnippetManager.Tests;
 
 public class SelectedTextBoundsPlausibilityTests
 {
+    private static readonly PixelRect MainDisplay = new(0, 0, 2560, 1440);
+    private static readonly PixelRect SecondaryLeftDisplay = new(-1920, 0, 1920, 1080);
+    private static readonly PixelRect SecondaryAboveDisplay = new(0, -1080, 1920, 1080);
+
     [Fact]
     public void NormalCaretBounds_Accepted()
     {
         // A caret at a reasonable position with normal line height.
         var bounds = new PixelRect(414, 896, 2, 17);
 
-        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
     }
 
     [Fact]
@@ -19,7 +23,7 @@ public class SelectedTextBoundsPlausibilityTests
         // A zero-width selection still has the line height.
         var bounds = new PixelRect(300, 200, 1, 16);
 
-        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
     }
 
     [Fact]
@@ -28,7 +32,7 @@ public class SelectedTextBoundsPlausibilityTests
         // A multi-character text selection.
         var bounds = new PixelRect(100, 300, 200, 18);
 
-        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
     }
 
     [Fact]
@@ -37,7 +41,7 @@ public class SelectedTextBoundsPlausibilityTests
         // 1×1 rect at a normal position (not at screen edge) is accepted.
         var bounds = new PixelRect(500, 400, 1, 1);
 
-        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
     }
 
     [Fact]
@@ -46,7 +50,7 @@ public class SelectedTextBoundsPlausibilityTests
         // 1×1 rect at X=0 — screen left edge.
         var bounds = new PixelRect(0, 500, 1, 1);
 
-        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
     }
 
     [Fact]
@@ -55,7 +59,7 @@ public class SelectedTextBoundsPlausibilityTests
         // 1×1 rect at Y=0 — screen top edge.
         var bounds = new PixelRect(500, 0, 1, 1);
 
-        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
     }
 
     [Fact]
@@ -64,7 +68,7 @@ public class SelectedTextBoundsPlausibilityTests
         // 1×1 rect at (0, 0) — screen corner.
         var bounds = new PixelRect(0, 0, 1, 1);
 
-        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
     }
 
     [Fact]
@@ -73,6 +77,88 @@ public class SelectedTextBoundsPlausibilityTests
         // A normally-sized rect at X=0 is fine — only degenerate sizes are suspicious.
         var bounds = new PixelRect(0, 500, 2, 17);
 
-        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
+    }
+
+    [Fact]
+    public void DegenerateBoundsAtRightEdge_Rejected()
+    {
+        // 1×1 rect at the right edge of the display.
+        var bounds = new PixelRect(2559, 500, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
+    }
+
+    [Fact]
+    public void DegenerateBoundsAtBottomEdge_Rejected()
+    {
+        // 1×1 rect at the bottom edge of the display.
+        var bounds = new PixelRect(500, 1439, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, MainDisplay));
+    }
+
+    [Fact]
+    public void SecondaryDisplay_NegativeCoordinates_ValidPosition_Accepted()
+    {
+        // A caret on a secondary display to the left (negative X coordinates).
+        var bounds = new PixelRect(-960, 540, 1, 1);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, SecondaryLeftDisplay));
+    }
+
+    [Fact]
+    public void SecondaryDisplay_DegenerateAtLeftEdge_Rejected()
+    {
+        // 1×1 rect at the left edge of a secondary display with negative coordinates.
+        var bounds = new PixelRect(-1920, 500, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, SecondaryLeftDisplay));
+    }
+
+    [Fact]
+    public void SecondaryDisplay_DegenerateAtRightEdge_Rejected()
+    {
+        // 1×1 rect at the right edge of the secondary left display (X=0 is the right edge).
+        var bounds = new PixelRect(-1, 500, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, SecondaryLeftDisplay));
+    }
+
+    [Fact]
+    public void SecondaryAboveDisplay_DegenerateAtTopEdge_Rejected()
+    {
+        // 1×1 rect at the top edge of a display above the main one (negative Y).
+        var bounds = new PixelRect(500, -1080, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, SecondaryAboveDisplay));
+    }
+
+    [Fact]
+    public void SecondaryAboveDisplay_ValidPosition_Accepted()
+    {
+        // A caret at a valid position on a display above the main one.
+        var bounds = new PixelRect(500, -540, 1, 1);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, SecondaryAboveDisplay));
+    }
+
+    [Fact]
+    public void NullScreenBounds_DegenerateSize_Accepted()
+    {
+        // When screen bounds are unavailable, a 1×1 rect is accepted
+        // since we can't verify screen edges.
+        var bounds = new PixelRect(0, 0, 1, 1);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, null));
+    }
+
+    [Fact]
+    public void NullScreenBounds_NormalSize_Accepted()
+    {
+        // Normal-sized bounds are always accepted regardless of screen info.
+        var bounds = new PixelRect(414, 896, 2, 17);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds, null));
     }
 }

--- a/test/Neptuo.Productivity.SnippetManager.Tests/SelectedTextBoundsPlausibilityTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/SelectedTextBoundsPlausibilityTests.cs
@@ -1,0 +1,78 @@
+using Avalonia;
+
+namespace Neptuo.Productivity.SnippetManager.Tests;
+
+public class SelectedTextBoundsPlausibilityTests
+{
+    [Fact]
+    public void NormalCaretBounds_Accepted()
+    {
+        // A caret at a reasonable position with normal line height.
+        var bounds = new PixelRect(414, 896, 2, 17);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+
+    [Fact]
+    public void ZeroWidthSelectionWithHeight_Accepted()
+    {
+        // A zero-width selection still has the line height.
+        var bounds = new PixelRect(300, 200, 1, 16);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+
+    [Fact]
+    public void WideSelection_Accepted()
+    {
+        // A multi-character text selection.
+        var bounds = new PixelRect(100, 300, 200, 18);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+
+    [Fact]
+    public void SmallBoundsAtValidPosition_Accepted()
+    {
+        // 1×1 rect at a normal position (not at screen edge) is accepted.
+        var bounds = new PixelRect(500, 400, 1, 1);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+
+    [Fact]
+    public void DegenerateBoundsAtLeftEdge_Rejected()
+    {
+        // 1×1 rect at X=0 — screen left edge.
+        var bounds = new PixelRect(0, 500, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+
+    [Fact]
+    public void DegenerateBoundsAtTopEdge_Rejected()
+    {
+        // 1×1 rect at Y=0 — screen top edge.
+        var bounds = new PixelRect(500, 0, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+
+    [Fact]
+    public void DegenerateBoundsAtOrigin_Rejected()
+    {
+        // 1×1 rect at (0, 0) — screen corner.
+        var bounds = new PixelRect(0, 0, 1, 1);
+
+        Assert.False(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+
+    [Fact]
+    public void NormalBoundsAtLeftEdge_Accepted()
+    {
+        // A normally-sized rect at X=0 is fine — only degenerate sizes are suspicious.
+        var bounds = new PixelRect(0, 500, 2, 17);
+
+        Assert.True(MacOSTextAnchor.IsSelectedTextBoundsPlausible(bounds));
+    }
+}

--- a/test/Neptuo.Productivity.SnippetManager.Tests/WindowPositioningTests.cs
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/WindowPositioningTests.cs
@@ -50,4 +50,18 @@ public class WindowPositioningTests
         Assert.Equal(220, position.X);
         Assert.Equal(660, position.Y);
     }
+
+    [Fact]
+    public void CalculatePosition_AlignsWithAnchorStartWhenAnchorIsWiderThanWindow()
+    {
+        // Simulates the Edge address bar: anchor is 1042px wide at X=222, window is 400px.
+        // Neither right (1264+400>1512) nor left (222-400<61) fits, so use anchorX.
+        var workingArea = new PixelRect(61, 33, 1451, 949);
+        var anchor = new WindowPositionAnchor(new PixelRect(222, 81, 1042, 24), "focused element");
+
+        var position = WindowPositioning.CalculatePosition(anchor, workingArea, windowWidth: 400, windowHeight: 100);
+
+        Assert.Equal(222, position.X);
+        Assert.Equal(105, position.Y);
+    }
 }


### PR DESCRIPTION
## Motivation

When opening the snippet manager with focus in the MS Edge address bar on macOS, the window appeared in the bottom-left corner of the screen instead of near the address bar. This happened because Chromium-based browsers return bogus accessibility bounds `(0, screenHeight, 1, 1)` from `AXBoundsForRange` for the address bar -- a known limitation of Chromium's macOS accessibility bridge with no upstream fix.

## Approach

Two complementary fixes:

**1. Reject degenerate accessibility bounds** (`MacOSTextAnchor.cs`)

Added a plausibility check (`IsSelectedTextBoundsPlausible`) that detects when `AXBoundsForRange` returns a 1x1 rect positioned at a screen edge. When detected, the selected-text-range result is discarded and the existing fallback chain continues (focused element -> focused element window -> focused window -> centered).

This uses CoreGraphics P/Invoke (`CGMainDisplayID`, `CGDisplayPixelsWide/High`) to check far screen edges, and simple coordinate checks for the origin edges.

**2. Improve positioning for wide anchor elements** (`WindowPositioning.cs`)

The focused-element fallback returns the entire address bar rect (e.g. 1042px wide). The old positioning logic tried to place the window to the right of the anchor, then to the left -- but for an anchor wider than the window, both options pushed the window off-screen, clamping it to the working area edge (X=61).

Now there is a 3-step fallback: right of anchor -> left of anchor -> align with anchor's start position. For the Edge address bar case, this places the window at `X=222` (start of the address bar) instead of `X=61` (screen edge).

## Testing

Added `SelectedTextBoundsPlausibilityTests` (8 tests) covering acceptance of normal carets, rejection of degenerate bounds at screen edges, and acceptance of small bounds at valid positions. Added a `WindowPositioningTests` case for the wide-anchor scenario. All 55 tests pass.