### PR TITLE
Upgrade solution from .NET 9 to .NET 10

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>Neptuo.Productivity.SnippetManager</RootNamespace>
     <NoWarn>NU1701</NoWarn>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <FrameworkPackageVersion>9.0.0</FrameworkPackageVersion>
+    <FrameworkPackageVersion>10.0.0</FrameworkPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Neptuo.Windows.Converters" Version="1.0.0" />

--- a/src/Neptuo.Productivity.SnippetManager.UI/Neptuo.Productivity.SnippetManager.UI.csproj
+++ b/src/Neptuo.Productivity.SnippetManager.UI/Neptuo.Productivity.SnippetManager.UI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <!-- Override Directory.Build.props to keep Windows-specific TFM for WPF -->
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/test/Neptuo.Productivity.SnippetManager.Tests/Neptuo.Productivity.SnippetManager.Tests.csproj
+++ b/test/Neptuo.Productivity.SnippetManager.Tests/Neptuo.Productivity.SnippetManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
The solution was targeting .NET 9. This upgrades all projects and shared build props to .NET 10.

## Changes

- `src/Directory.Build.props` -- TFM `net9.0` to `net10.0` (applies to most projects)
- `src/Directory.Packages.props` -- `FrameworkPackageVersion` `9.0.0` to `10.0.0`
- `src/Neptuo.Productivity.SnippetManager.UI` -- TFM `net9.0-windows10.0.26100.0` to `net10.0-windows10.0.26100.0`
- `test/Neptuo.Productivity.SnippetManager.Tests` -- TFM `net9.0` to `net10.0`

All 64 tests pass on `net10.0`.

## Note

The `.github/workflows/tests.yml` CI workflow also needs `dotnet-version` updated from `9.0.x` to `10.0.x`. That change is ready locally but could not be pushed due to the OAuth token lacking the `workflow` scope. It should be committed separately with appropriate permissions.