### PR TITLE
Show tray notification when global hotkey fails due to missing permissions

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Hotkey.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Hotkey.cs
@@ -10,6 +10,8 @@ public class Hotkey : IDisposable
     private (KeyCode key, ModifierMask modifiers)? hotkey;
     private Action? openMainAction;
 
+    public event Action<string>? HookFailed;
+
     public void Bind(Navigator navigator, string? rawHotkey)
     {
         string effectiveHotkey = string.IsNullOrWhiteSpace(rawHotkey)
@@ -42,7 +44,7 @@ public class Hotkey : IDisposable
 
         hook = CreateHook();
         DiagnosticsLog.Info("Starting global hotkey hook.");
-        StartHookAsync(hook);
+        StartHookAsync(hook, HookFailed);
     }
 
     private void OnKeyPressed(object? sender, KeyboardHookEventArgs e)
@@ -204,7 +206,7 @@ public class Hotkey : IDisposable
             if (!hook.IsRunning)
             {
                 DiagnosticsLog.Info("Restarting the global hotkey hook.");
-                StartHookAsync(hook);
+                StartHookAsync(hook, HookFailed);
             }
             else
             {
@@ -226,12 +228,33 @@ public class Hotkey : IDisposable
         return createdHook;
     }
 
-    private static void StartHookAsync(SimpleGlobalHook hook)
+    private static void StartHookAsync(SimpleGlobalHook hook, Action<string>? hookFailed)
     {
         Task runTask = hook.RunAsync();
         _ = runTask.ContinueWith(
-            task => DiagnosticsLog.Error("The global hotkey hook terminated with an exception.", task.Exception),
+            task =>
+            {
+                DiagnosticsLog.Error("The global hotkey hook terminated with an exception.", task.Exception);
+
+                string? message = GetHookFailureMessage(task.Exception);
+                if (message != null)
+                    hookFailed?.Invoke(message);
+            },
             TaskContinuationOptions.OnlyOnFaulted);
+    }
+
+    private static string? GetHookFailureMessage(AggregateException? exception)
+    {
+        if (exception == null)
+            return null;
+
+        foreach (var inner in exception.Flatten().InnerExceptions)
+        {
+            if (inner is HookException hookEx && hookEx.Result == SharpHook.Native.UioHookResult.ErrorAxApiDisabled)
+                return "Global hotkey unavailable — grant Accessibility permission in System Settings > Privacy & Security > Accessibility.";
+        }
+
+        return "Global hotkey failed to start.";
     }
 
     private void LogRelevantKeyEvent(string eventName, KeyboardHookEventArgs e, bool keyMatch, bool modifiersMatch)

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/TrayIcon.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/TrayIcon.cs
@@ -57,6 +57,8 @@ public class TrayIcon : IDisposable
             IsVisible = true
         };
 
+        hotkey.HookFailed += OnHookFailed;
+
         // Set icon from embedded Avalonia resource
         try
         {
@@ -79,6 +81,13 @@ public class TrayIcon : IDisposable
         trayIcon.Clicked += (_, _) => navigator.OpenMain(stickToActiveCaret: false);
     }
 
+    private void OnHookFailed(string message)
+    {
+        trayIcon.ToolTipText = $"Snippet Manager — {message}";
+        if (hotkeyMenuItem != null)
+            hotkeyMenuItem.Header = "Hotkey unavailable";
+    }
+
     private void ToggleHotkey()
     {
         if (isPaused)
@@ -97,6 +106,7 @@ public class TrayIcon : IDisposable
 
     public void Dispose()
     {
+        hotkey.HookFailed -= OnHookFailed;
         trayIcon.IsVisible = false;
         trayIcon.Dispose();
     }


### PR DESCRIPTION
When the SharpHook global hook fails to start on macOS -- most commonly because Accessibility permission has not been granted (`ErrorAxApiDisabled`) -- the error is currently only written to the diagnostics log. There is no visible indication to the user that the hotkey is not working.

## Approach

A `HookFailed` event is added to the `Hotkey` class. It fires on the `RunAsync` continuation when the hook task faults, inspecting the inner exceptions to produce a targeted message:

- **`ErrorAxApiDisabled`** -- tells the user to grant Accessibility permission in System Settings.
- **Any other failure** -- shows a generic "failed to start" message.

`TrayIcon` subscribes to this event and updates two things:

- **Tooltip** -- changes from "Snippet Manager" to include the failure reason, so hovering the tray icon explains the problem.
- **Menu item** -- changes from "Pause hotkey" to "Hotkey unavailable", preventing misleading pause/restore toggling.

No modal dialogs are shown; the notification is passive and non-intrusive.