### PR TITLE
Log frontmost macOS app name and bundle id for anchoring diagnostics

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
@@ -3,27 +3,57 @@ using System.Globalization;
 
 namespace Neptuo.Productivity.SnippetManager;
 
+internal readonly record struct FrontmostApplication(int ProcessId, string? Name, string? BundleIdentifier)
+{
+    public string DescribeForLog()
+    {
+        string name = string.IsNullOrEmpty(Name) ? "<unknown>" : Name;
+        string bundle = string.IsNullOrEmpty(BundleIdentifier) ? "<unknown>" : BundleIdentifier;
+        return $"pid={ProcessId}, name='{name}', bundle='{bundle}'";
+    }
+}
+
 internal static class MacOSApplication
 {
-    public static int? GetFrontmostApplicationProcessId()
+    public static FrontmostApplication? GetFrontmostApplication()
     {
         if (!OperatingSystem.IsMacOS())
             return null;
 
         string? output = RunAppleScript("""
             tell application "System Events"
-                unix id of first application process whose frontmost is true
+                set p to first application process whose frontmost is true
+                set n to ""
+                try
+                    set n to name of p
+                end try
+                set b to ""
+                try
+                    set b to bundle identifier of p
+                end try
+                return ((unix id of p) as string) & tab & n & tab & b
             end tell
             """);
 
-        if (int.TryParse(output, NumberStyles.Integer, CultureInfo.InvariantCulture, out int processId))
+        if (string.IsNullOrEmpty(output))
         {
-            DiagnosticsLog.Info($"Resolved the frontmost macOS application PID to {processId}.");
-            return processId;
+            DiagnosticsLog.Error("Unable to resolve the frontmost macOS application (empty AppleScript output).");
+            return null;
         }
 
-        DiagnosticsLog.Error($"Unable to parse the frontmost macOS application PID from '{output}'.");
-        return null;
+        string[] parts = output.Split('\t');
+        if (parts.Length == 0 || !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int processId))
+        {
+            DiagnosticsLog.Error($"Unable to parse the frontmost macOS application info from '{output}'.");
+            return null;
+        }
+
+        string? name = parts.Length > 1 && !string.IsNullOrEmpty(parts[1]) ? parts[1] : null;
+        string? bundle = parts.Length > 2 && !string.IsNullOrEmpty(parts[2]) ? parts[2] : null;
+
+        var app = new FrontmostApplication(processId, name, bundle);
+        DiagnosticsLog.Info($"Resolved the frontmost macOS application: {app.DescribeForLog()}.");
+        return app;
     }
 
     public static void ActivateCurrentProcess()
@@ -32,12 +62,13 @@ internal static class MacOSApplication
         ActivateProcess(Environment.ProcessId);
     }
 
-    public static void ActivateProcess(int processId)
+    public static void ActivateProcess(int processId, string? name = null)
     {
         if (!OperatingSystem.IsMacOS() || processId <= 0)
             return;
 
-        DiagnosticsLog.Info($"Requesting macOS activation for process {processId}.");
+        string suffix = string.IsNullOrEmpty(name) ? string.Empty : $" (name='{name}')";
+        DiagnosticsLog.Info($"Requesting macOS activation for process {processId}{suffix}.");
         RunAppleScript($"""
             tell application "System Events"
                 set frontmost of first application process whose unix id is {processId} to true

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 
 namespace Neptuo.Productivity.SnippetManager;
 
@@ -7,9 +8,37 @@ internal readonly record struct FrontmostApplication(int ProcessId, string? Name
 {
     public string DescribeForLog()
     {
-        string name = string.IsNullOrEmpty(Name) ? "<unknown>" : Name;
-        string bundle = string.IsNullOrEmpty(BundleIdentifier) ? "<unknown>" : BundleIdentifier;
-        return $"pid={ProcessId}, name='{name}', bundle='{bundle}'";
+        string name = FormatLogValue(Name);
+        string bundle = FormatLogValue(BundleIdentifier);
+        return $"pid={ProcessId}, name={name}, bundle={bundle}";
+    }
+
+    private static string FormatLogValue(string? value)
+        => string.IsNullOrEmpty(value) ? "<unknown>" : QuoteForLog(value);
+
+    private static string QuoteForLog(string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('"');
+        foreach (char c in value)
+        {
+            switch (c)
+            {
+                case '\\': builder.Append("\\\\"); break;
+                case '"': builder.Append("\\\""); break;
+                case '\n': builder.Append("\\n"); break;
+                case '\r': builder.Append("\\r"); break;
+                case '\t': builder.Append("\\t"); break;
+                default:
+                    if (c < 0x20)
+                        builder.Append("\\u").Append(((int)c).ToString("X4", CultureInfo.InvariantCulture));
+                    else
+                        builder.Append(c);
+                    break;
+            }
+        }
+        builder.Append('"');
+        return builder.ToString();
     }
 }
 
@@ -23,6 +52,7 @@ internal static class MacOSApplication
         string? output = RunAppleScript("""
             tell application "System Events"
                 set p to first application process whose frontmost is true
+                set sep to (character id 31)
                 set n to ""
                 try
                     set n to name of p
@@ -31,7 +61,7 @@ internal static class MacOSApplication
                 try
                     set b to bundle identifier of p
                 end try
-                return ((unix id of p) as string) & tab & n & tab & b
+                return ((unix id of p) as string) & sep & n & sep & b
             end tell
             """);
 
@@ -41,12 +71,15 @@ internal static class MacOSApplication
             return null;
         }
 
-        string[] parts = output.Split('\t');
+        string[] parts = output.Split(new[] { '\u001F' }, 3);
         if (parts.Length == 0 || !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int processId))
         {
             DiagnosticsLog.Error($"Unable to parse the frontmost macOS application info from '{output}'.");
             return null;
         }
+
+        if (parts.Length < 3)
+            DiagnosticsLog.Error($"Frontmost macOS application info is missing fields (got {parts.Length}): '{output}'.");
 
         string? name = parts.Length > 1 && !string.IsNullOrEmpty(parts[1]) ? parts[1] : null;
         string? bundle = parts.Length > 2 && !string.IsNullOrEmpty(parts[2]) ? parts[2] : null;

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSTextAnchor.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSTextAnchor.cs
@@ -7,88 +7,90 @@ namespace Neptuo.Productivity.SnippetManager;
 
 internal static class MacOSTextAnchor
 {
-    public static WindowPositionAnchor? TryGetForFocusedElement()
+    public static WindowPositionAnchor? TryGetForFocusedElement(string? frontmostAppLabel = null)
     {
         if (!OperatingSystem.IsMacOS())
             return null;
 
-        DiagnosticsLog.Info("Attempting to resolve a macOS accessibility anchor for main window positioning.");
+        string context = string.IsNullOrEmpty(frontmostAppLabel) ? string.Empty : $" Frontmost app: {frontmostAppLabel}.";
+
+        DiagnosticsLog.Info($"Attempting to resolve a macOS accessibility anchor for main window positioning.{context}");
 
         try
         {
             if (!NativeMethods.AXIsProcessTrusted())
-                DiagnosticsLog.Info("macOS accessibility reports the current process is not trusted. Focused-element placement may be unavailable.");
+                DiagnosticsLog.Info($"macOS accessibility reports the current process is not trusted. Focused-element placement may be unavailable.{context}");
 
             using CFObjectHandle? systemWide = CFObjectHandle.Own(NativeMethods.AXUIElementCreateSystemWide());
             if (systemWide == null || systemWide.IsInvalid)
             {
-                DiagnosticsLog.Error("Unable to create the system-wide macOS accessibility element.");
+                DiagnosticsLog.Error($"Unable to create the system-wide macOS accessibility element.{context}");
                 return null;
             }
 
-            if (TryCopyAttributeValue(systemWide, "AXFocusedUIElement", out var focusedElement))
+            if (TryCopyAttributeValue(systemWide, "AXFocusedUIElement", out var focusedElement, context))
             {
                 using (focusedElement)
                 {
-                    if (TryGetSelectedTextRangeBounds(focusedElement, out var selectedTextBounds))
-                        return CreateAnchor(selectedTextBounds, "selected text range");
+                    if (TryGetSelectedTextRangeBounds(focusedElement, out var selectedTextBounds, context))
+                        return CreateAnchor(selectedTextBounds, "selected text range", context);
 
-                    if (TryGetElementBounds(focusedElement, out var focusedElementBounds))
-                        return CreateAnchor(focusedElementBounds, "focused element");
+                    if (TryGetElementBounds(focusedElement, out var focusedElementBounds, context))
+                        return CreateAnchor(focusedElementBounds, "focused element", context);
 
-                    if (TryCopyAttributeValue(focusedElement, "AXWindow", out var elementWindow))
+                    if (TryCopyAttributeValue(focusedElement, "AXWindow", out var elementWindow, context))
                     {
                         using (elementWindow)
                         {
-                            if (TryGetElementBounds(elementWindow, out var elementWindowBounds))
-                                return CreateAnchor(elementWindowBounds, "focused element window");
+                            if (TryGetElementBounds(elementWindow, out var elementWindowBounds, context))
+                                return CreateAnchor(elementWindowBounds, "focused element window", context);
                         }
                     }
                 }
             }
 
-            if (TryCopyAttributeValue(systemWide, "AXFocusedWindow", out var focusedWindow))
+            if (TryCopyAttributeValue(systemWide, "AXFocusedWindow", out var focusedWindow, context))
             {
                 using (focusedWindow)
                 {
-                    if (TryGetElementBounds(focusedWindow, out var focusedWindowBounds))
-                        return CreateAnchor(focusedWindowBounds, "focused window");
+                    if (TryGetElementBounds(focusedWindow, out var focusedWindowBounds, context))
+                        return CreateAnchor(focusedWindowBounds, "focused window", context);
                 }
             }
         }
         catch (Exception ex)
         {
-            DiagnosticsLog.Error("Unable to resolve a macOS accessibility anchor for main window positioning.", ex);
+            DiagnosticsLog.Error($"Unable to resolve a macOS accessibility anchor for main window positioning.{context}", ex);
         }
 
-        DiagnosticsLog.Info("Unable to resolve a macOS accessibility anchor. The main window will fall back to centered placement.");
+        DiagnosticsLog.Info($"Unable to resolve a macOS accessibility anchor. The main window will fall back to centered placement.{context}");
         return null;
     }
 
-    private static bool TryGetSelectedTextRangeBounds(CFObjectHandle element, out PixelRect bounds)
+    private static bool TryGetSelectedTextRangeBounds(CFObjectHandle element, out PixelRect bounds, string context = "")
     {
         bounds = default;
 
-        if (!TryCopyAttributeValue(element, "AXSelectedTextRange", out var selectedTextRange))
+        if (!TryCopyAttributeValue(element, "AXSelectedTextRange", out var selectedTextRange, context))
             return false;
 
         using (selectedTextRange)
         {
-            if (!TryCopyParameterizedAttributeValue(element, "AXBoundsForRange", selectedTextRange, out var selectedTextBounds))
+            if (!TryCopyParameterizedAttributeValue(element, "AXBoundsForRange", selectedTextRange, out var selectedTextBounds, context))
                 return false;
 
             using (selectedTextBounds)
             {
-                if (!TryGetRectValue(selectedTextBounds, out var selectedRangeRect))
+                if (!TryGetRectValue(selectedTextBounds, out var selectedRangeRect, context))
                     return false;
 
                 bounds = ToPixelRect(selectedRangeRect);
-                DiagnosticsLog.Info($"Resolved macOS selected text bounds to {FormatPixelRect(bounds)}.");
+                DiagnosticsLog.Info($"Resolved macOS selected text bounds to {FormatPixelRect(bounds)}.{context}");
 
                 PixelRect? screenBounds = TryGetDisplayBoundsForPoint(bounds);
                 if (!IsSelectedTextBoundsPlausible(bounds, screenBounds))
                 {
-                    DiagnosticsLog.Info($"Rejected macOS selected text bounds {FormatPixelRect(bounds)} as implausible (degenerate size at screen edge). Falling back to alternative anchoring.");
+                    DiagnosticsLog.Info($"Rejected macOS selected text bounds {FormatPixelRect(bounds)} as implausible (degenerate size at screen edge). Falling back to alternative anchoring.{context}");
                     bounds = default;
                     return false;
                 }
@@ -139,108 +141,108 @@ internal static class MacOSTextAnchor
         }
     }
 
-    private static bool TryGetElementBounds(CFObjectHandle element, out PixelRect bounds)
+    private static bool TryGetElementBounds(CFObjectHandle element, out PixelRect bounds, string context = "")
     {
         bounds = default;
 
-        if (!TryCopyAttributeValue(element, "AXPosition", out var positionValue))
+        if (!TryCopyAttributeValue(element, "AXPosition", out var positionValue, context))
             return false;
 
         using (positionValue)
         {
-            if (!TryGetPointValue(positionValue, out var position))
+            if (!TryGetPointValue(positionValue, out var position, context))
                 return false;
 
-            if (!TryCopyAttributeValue(element, "AXSize", out var sizeValue))
+            if (!TryCopyAttributeValue(element, "AXSize", out var sizeValue, context))
                 return false;
 
             using (sizeValue)
             {
-                if (!TryGetSizeValue(sizeValue, out var size))
+                if (!TryGetSizeValue(sizeValue, out var size, context))
                     return false;
 
                 bounds = ToPixelRect(position, size);
-                DiagnosticsLog.Info($"Resolved macOS accessibility element bounds to {FormatPixelRect(bounds)}.");
+                DiagnosticsLog.Info($"Resolved macOS accessibility element bounds to {FormatPixelRect(bounds)}.{context}");
                 return true;
             }
         }
     }
 
-    private static WindowPositionAnchor CreateAnchor(PixelRect bounds, string source)
+    private static WindowPositionAnchor CreateAnchor(PixelRect bounds, string source, string context = "")
     {
-        DiagnosticsLog.Info($"Resolved macOS accessibility anchor from {source}: {FormatPixelRect(bounds)}.");
+        DiagnosticsLog.Info($"Resolved macOS accessibility anchor from {source}: {FormatPixelRect(bounds)}.{context}");
         return new WindowPositionAnchor(bounds, source);
     }
 
-    private static bool TryGetPointValue(CFObjectHandle value, out CGPoint point)
+    private static bool TryGetPointValue(CFObjectHandle value, out CGPoint point, string context = "")
     {
         point = default;
         if (NativeMethods.AXValueGetType(value) != AXValueType.CGPoint)
         {
-            DiagnosticsLog.Info("The macOS accessibility value did not contain a CGPoint.");
+            DiagnosticsLog.Info($"The macOS accessibility value did not contain a CGPoint.{context}");
             return false;
         }
 
         if (!NativeMethods.AXValueGetCGPoint(value, AXValueType.CGPoint, out point))
         {
-            DiagnosticsLog.Info("Unable to read a CGPoint from the macOS accessibility value.");
+            DiagnosticsLog.Info($"Unable to read a CGPoint from the macOS accessibility value.{context}");
             return false;
         }
 
         return true;
     }
 
-    private static bool TryGetSizeValue(CFObjectHandle value, out CGSize size)
+    private static bool TryGetSizeValue(CFObjectHandle value, out CGSize size, string context = "")
     {
         size = default;
         if (NativeMethods.AXValueGetType(value) != AXValueType.CGSize)
         {
-            DiagnosticsLog.Info("The macOS accessibility value did not contain a CGSize.");
+            DiagnosticsLog.Info($"The macOS accessibility value did not contain a CGSize.{context}");
             return false;
         }
 
         if (!NativeMethods.AXValueGetCGSize(value, AXValueType.CGSize, out size))
         {
-            DiagnosticsLog.Info("Unable to read a CGSize from the macOS accessibility value.");
+            DiagnosticsLog.Info($"Unable to read a CGSize from the macOS accessibility value.{context}");
             return false;
         }
 
         return true;
     }
 
-    private static bool TryGetRectValue(CFObjectHandle value, out CGRect rect)
+    private static bool TryGetRectValue(CFObjectHandle value, out CGRect rect, string context = "")
     {
         rect = default;
         if (NativeMethods.AXValueGetType(value) != AXValueType.CGRect)
         {
-            DiagnosticsLog.Info("The macOS accessibility value did not contain a CGRect.");
+            DiagnosticsLog.Info($"The macOS accessibility value did not contain a CGRect.{context}");
             return false;
         }
 
         if (!NativeMethods.AXValueGetCGRect(value, AXValueType.CGRect, out rect))
         {
-            DiagnosticsLog.Info("Unable to read a CGRect from the macOS accessibility value.");
+            DiagnosticsLog.Info($"Unable to read a CGRect from the macOS accessibility value.{context}");
             return false;
         }
 
         return true;
     }
 
-    private static bool TryCopyAttributeValue(CFObjectHandle element, string attributeName, [NotNullWhen(true)] out CFObjectHandle? value)
+    private static bool TryCopyAttributeValue(CFObjectHandle element, string attributeName, [NotNullWhen(true)] out CFObjectHandle? value, string context = "")
     {
         value = null;
 
         using CFObjectHandle? attribute = CreateString(attributeName);
         if (attribute == null || attribute.IsInvalid)
         {
-            DiagnosticsLog.Error($"Unable to create the macOS accessibility attribute string '{attributeName}'.");
+            DiagnosticsLog.Error($"Unable to create the macOS accessibility attribute string '{attributeName}'.{context}");
             return false;
         }
 
         AXError error = NativeMethods.AXUIElementCopyAttributeValue(element, attribute, out IntPtr rawValue);
         if (error != AXError.Success || rawValue == IntPtr.Zero)
         {
-            DiagnosticsLog.Info($"macOS accessibility attribute '{attributeName}' is unavailable (error={error}).");
+            DiagnosticsLog.Info($"macOS accessibility attribute '{attributeName}' is unavailable (error={error}).{context}");
             return false;
         }
 
@@ -248,21 +250,21 @@ internal static class MacOSTextAnchor
         return value != null && !value.IsInvalid;
     }
 
-    private static bool TryCopyParameterizedAttributeValue(CFObjectHandle element, string attributeName, CFObjectHandle parameter, [NotNullWhen(true)] out CFObjectHandle? value)
+    private static bool TryCopyParameterizedAttributeValue(CFObjectHandle element, string attributeName, CFObjectHandle parameter, [NotNullWhen(true)] out CFObjectHandle? value, string context = "")
     {
         value = null;
 
         using CFObjectHandle? attribute = CreateString(attributeName);
         if (attribute == null || attribute.IsInvalid)
         {
-            DiagnosticsLog.Error($"Unable to create the macOS accessibility parameterized attribute string '{attributeName}'.");
+            DiagnosticsLog.Error($"Unable to create the macOS accessibility parameterized attribute string '{attributeName}'.{context}");
             return false;
         }
 
         AXError error = NativeMethods.AXUIElementCopyParameterizedAttributeValue(element, attribute, parameter, out IntPtr rawValue);
         if (error != AXError.Success || rawValue == IntPtr.Zero)
         {
-            DiagnosticsLog.Info($"macOS parameterized accessibility attribute '{attributeName}' is unavailable (error={error}).");
+            DiagnosticsLog.Info($"macOS parameterized accessibility attribute '{attributeName}' is unavailable (error={error}).{context}");
             return false;
         }
 

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Navigator.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Navigator.cs
@@ -27,7 +27,7 @@ public class Navigator : IClipboardService, ISendTextService, INavigator
     private readonly Func<string> getCurrentHotkey;
     private readonly ConfigurationRepository configurationRepository;
     private readonly SnippetExpansionPipeline expansionPipeline;
-    private int? lastExternalProcessId;
+    private FrontmostApplication? lastExternalApplication;
 
     public Navigator(ISnippetProvider snippetProvider, ConfigurationRepository configurationRepository, Action<bool> setConfigChangeEnabled, Action shutdown, Func<Configuration> getExampleConfiguration, Func<string> getCurrentHotkey, VariablesConfiguration? variables)
     {
@@ -59,6 +59,7 @@ public class Navigator : IClipboardService, ISendTextService, INavigator
     {
         DiagnosticsLog.Info($"Navigator.Open requested. Existing window: {main != null}. stickToActiveCaret={stickToActiveCaret}.");
         RememberLastExternalApplication();
+        string? frontmostLabel = DescribeLastExternalApplication();
         bool shouldRefreshSnippets = false;
 
         if (main == null)
@@ -66,12 +67,12 @@ public class Navigator : IClipboardService, ISendTextService, INavigator
             main = new MainWindow();
             main.Closed += (sender, e) => { main = null; };
             main.ViewModel = new MainViewModel(snippetProviderContext, new ApplySnippetCommand(this, expansionPipeline), new CopySnippetCommand(this, expansionPipeline));
-            UpdateWindowPositionAnchor(main, stickToActiveCaret);
+            UpdateWindowPositionAnchor(main, stickToActiveCaret, frontmostLabel);
             shouldRefreshSnippets = true;
         }
         else
         {
-            UpdateWindowPositionAnchor(main, stickToActiveCaret);
+            UpdateWindowPositionAnchor(main, stickToActiveCaret, frontmostLabel);
             main.FocusSearchText();
             main.UpdatePosition();
         }
@@ -88,20 +89,22 @@ public class Navigator : IClipboardService, ISendTextService, INavigator
         DiagnosticsLog.Info("Main window shown and focused.");
     }
 
-    private static void UpdateWindowPositionAnchor(MainWindow window, bool stickToActiveCaret)
+    private static void UpdateWindowPositionAnchor(MainWindow window, bool stickToActiveCaret, string? frontmostAppLabel = null)
     {
         WindowPositionAnchor? anchor = null;
 
         if (stickToActiveCaret)
         {
-            anchor = MacOSTextAnchor.TryGetForFocusedElement();
+            anchor = MacOSTextAnchor.TryGetForFocusedElement(frontmostAppLabel);
             if (anchor is { } resolvedAnchor)
             {
-                DiagnosticsLog.Info($"Main window positioning will use the {resolvedAnchor.Source} anchor at ({resolvedAnchor.Bounds.X}, {resolvedAnchor.Bounds.Y}, {resolvedAnchor.Bounds.Width}, {resolvedAnchor.Bounds.Height}).");
+                string suffix = string.IsNullOrEmpty(frontmostAppLabel) ? string.Empty : $" Frontmost app: {frontmostAppLabel}.";
+                DiagnosticsLog.Info($"Main window positioning will use the {resolvedAnchor.Source} anchor at ({resolvedAnchor.Bounds.X}, {resolvedAnchor.Bounds.Y}, {resolvedAnchor.Bounds.Width}, {resolvedAnchor.Bounds.Height}).{suffix}");
             }
             else
             {
-                DiagnosticsLog.Info("Unable to resolve a caret or focused-element anchor for the main window. Falling back to centered placement.");
+                string suffix = string.IsNullOrEmpty(frontmostAppLabel) ? string.Empty : $" Frontmost app: {frontmostAppLabel}.";
+                DiagnosticsLog.Info($"Unable to resolve a caret or focused-element anchor for the main window. Falling back to centered placement.{suffix}");
             }
         }
         else
@@ -373,17 +376,21 @@ public class Navigator : IClipboardService, ISendTextService, INavigator
         if (!OperatingSystem.IsMacOS())
             return;
 
-        int? processId = MacOSApplication.GetFrontmostApplicationProcessId();
-        if (processId.HasValue && processId.Value != Environment.ProcessId)
+        FrontmostApplication? app = MacOSApplication.GetFrontmostApplication();
+        if (app is { } value && value.ProcessId != Environment.ProcessId)
         {
-            lastExternalProcessId = processId.Value;
-            DiagnosticsLog.Info($"Captured frontmost macOS application PID {processId.Value} before opening the UI.");
+            lastExternalApplication = value;
+            DiagnosticsLog.Info($"Captured frontmost macOS application before opening the UI: {value.DescribeForLog()}.");
         }
         else
         {
-            DiagnosticsLog.Info("No external macOS application PID was captured before opening the UI.");
+            lastExternalApplication = null;
+            DiagnosticsLog.Info("No external macOS application was captured before opening the UI.");
         }
     }
+
+    private string? DescribeLastExternalApplication()
+        => lastExternalApplication?.DescribeForLog();
 
     private static void ActivateCurrentApplication()
     {
@@ -393,13 +400,13 @@ public class Navigator : IClipboardService, ISendTextService, INavigator
 
     private void RestoreLastExternalApplication()
     {
-        int? processId = lastExternalProcessId;
-        lastExternalProcessId = null;
+        FrontmostApplication? app = lastExternalApplication;
+        lastExternalApplication = null;
 
-        if (OperatingSystem.IsMacOS() && processId.HasValue && processId.Value != Environment.ProcessId)
+        if (OperatingSystem.IsMacOS() && app is { } value && value.ProcessId != Environment.ProcessId)
         {
-            DiagnosticsLog.Info($"Restoring focus to macOS process {processId.Value}.");
-            MacOSApplication.ActivateProcess(processId.Value);
+            DiagnosticsLog.Info($"Restoring focus to macOS application: {value.DescribeForLog()}.");
+            MacOSApplication.ActivateProcess(value.ProcessId, value.Name);
         }
     }
 

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/Navigator.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/Navigator.cs
@@ -95,15 +95,14 @@ public class Navigator : IClipboardService, ISendTextService, INavigator
 
         if (stickToActiveCaret)
         {
+            string suffix = string.IsNullOrEmpty(frontmostAppLabel) ? string.Empty : $" Frontmost app: {frontmostAppLabel}.";
             anchor = MacOSTextAnchor.TryGetForFocusedElement(frontmostAppLabel);
             if (anchor is { } resolvedAnchor)
             {
-                string suffix = string.IsNullOrEmpty(frontmostAppLabel) ? string.Empty : $" Frontmost app: {frontmostAppLabel}.";
                 DiagnosticsLog.Info($"Main window positioning will use the {resolvedAnchor.Source} anchor at ({resolvedAnchor.Bounds.X}, {resolvedAnchor.Bounds.Y}, {resolvedAnchor.Bounds.Width}, {resolvedAnchor.Bounds.Height}).{suffix}");
             }
             else
             {
-                string suffix = string.IsNullOrEmpty(frontmostAppLabel) ? string.Empty : $" Frontmost app: {frontmostAppLabel}.";
                 DiagnosticsLog.Info($"Unable to resolve a caret or focused-element anchor for the main window. Falling back to centered placement.{suffix}");
             }
         }


### PR DESCRIPTION
When the snippet window fails to anchor to the focused text field on macOS, `diagnostics.log` only recorded the frontmost application's PID. By the time I went to triage the log later, those PIDs were long gone, so it was impossible to tell which apps were breaking anchoring (the current log has five PIDs that always fail and a Chromium-ish PID that intermittently produces degenerate `(0,982,1,1)` caret bounds, but none of them are identifiable).

This PR threads the frontmost app's localized name and bundle identifier through the anchoring path so every related log line is attributable to a specific app.

## Approach

- `MacOSApplication.GetFrontmostApplicationProcessId()` becomes `GetFrontmostApplication()` and returns a new `FrontmostApplication` record (`ProcessId`, `Name`, `BundleIdentifier`). A single `osascript` call returns `pid \t name \t bundle` with `try` blocks around `name`/`bundle identifier` so processes that don't expose them still yield a usable PID.
- `Navigator` stores the whole record (was just `int?`) and passes a `frontmostAppLabel` string into `UpdateWindowPositionAnchor` and on into `MacOSTextAnchor.TryGetForFocusedElement`.
- `MacOSTextAnchor` appends ` Frontmost app: pid=..., name='...', bundle='...'.` to every Info/Error line in the anchor pipeline: the initial attempt, each `AXFocusedUIElement` / `AXFocusedWindow` / `AXBoundsForRange` failure, the degenerate-bounds rejection, and the final centered-placement fallback. Empty labels produce no suffix, so behavior is unchanged when the PID capture fails.
- `ActivateProcess` also accepts an optional `name` so the "Restoring focus to macOS process ..." line includes it.

## Notes for reviewers

- No functional behavior changes for positioning or focus restoration, only logging.
- The AppleScript uses `tab` as a separator and empty strings for unavailable fields; confirmed on macOS the output is e.g. `94697\tgithub\tcom.copilot.tauri\n`.
- Existing `SelectedTextBoundsPlausibilityTests` still pass (110/110). `MacOSTextAnchor.TryGetForFocusedElement` gained an optional parameter with a default, so callers outside the Avalonia project are unaffected.