### PR TITLE
Faster frontmost app detection on macOS via NSWorkspace + CGEvent

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
@@ -54,7 +54,10 @@ internal static class MacOSApplication
             IntPtr workspaceClass = ObjC.objc_getClass("NSWorkspace");
             if (workspaceClass == IntPtr.Zero)
             {
-                DiagnosticsLog.Error("Unable to resolve the NSWorkspace class via the Objective-C runtime.");
+                if (ObjC.AppKitHandle == IntPtr.Zero)
+                    DiagnosticsLog.Error("Unable to resolve the NSWorkspace class: AppKit failed to load.");
+                else
+                    DiagnosticsLog.Error("Unable to resolve the NSWorkspace class via the Objective-C runtime.");
                 return null;
             }
 
@@ -211,7 +214,7 @@ internal static class MacOSApplication
         private const string AppKitPath = "/System/Library/Frameworks/AppKit.framework/AppKit";
 
         // Ensure AppKit is loaded so NSWorkspace is available. Idempotent; a no-op when Avalonia has already linked it.
-        private static readonly IntPtr AppKitHandle = dlopen(AppKitPath, 2 /* RTLD_NOW */);
+        public static readonly IntPtr AppKitHandle = LoadAppKit();
 
         public static readonly IntPtr Sel_sharedWorkspace = sel_registerName("sharedWorkspace");
         public static readonly IntPtr Sel_frontmostApplication = sel_registerName("frontmostApplication");
@@ -255,6 +258,14 @@ internal static class MacOSApplication
 
             string? value = Marshal.PtrToStringUTF8(utf8);
             return string.IsNullOrEmpty(value) ? null : value;
+        }
+
+        private static IntPtr LoadAppKit()
+        {
+            IntPtr handle = dlopen(AppKitPath, 2 /* RTLD_NOW */);
+            if (handle == IntPtr.Zero)
+                DiagnosticsLog.Error($"dlopen failed to load AppKit from '{AppKitPath}'; NSWorkspace lookups will not work.");
+            return handle;
         }
     }
 }

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -107,11 +106,33 @@ internal static class MacOSApplication
 
         string suffix = string.IsNullOrEmpty(name) ? string.Empty : $" (name='{name}')";
         DiagnosticsLog.Info($"Requesting macOS activation for process {processId}{suffix}.");
-        RunAppleScript($"""
-            tell application "System Events"
-                set frontmost of first application process whose unix id is {processId} to true
-            end tell
-            """);
+
+        try
+        {
+            IntPtr runningAppClass = ObjC.objc_getClass("NSRunningApplication");
+            if (runningAppClass == IntPtr.Zero)
+            {
+                DiagnosticsLog.Error("Unable to resolve the NSRunningApplication class.");
+                return;
+            }
+
+            IntPtr app = ObjC.IntPtr_IntPtr_objc_msgSend(runningAppClass, ObjC.Sel_runningApplicationWithProcessIdentifier, new IntPtr(processId));
+            if (app == IntPtr.Zero)
+            {
+                DiagnosticsLog.Error($"No NSRunningApplication found for PID {processId}.");
+                return;
+            }
+
+            // NSApplicationActivateIgnoringOtherApps = 1 << 1
+            const ulong NSApplicationActivateIgnoringOtherApps = 1UL << 1;
+            bool ok = ObjC.Bool_ULong_objc_msgSend(app, ObjC.Sel_activateWithOptions, NSApplicationActivateIgnoringOtherApps);
+            if (!ok)
+                DiagnosticsLog.Error($"NSRunningApplication activateWithOptions: returned NO for PID {processId}.");
+        }
+        catch (Exception ex)
+        {
+            DiagnosticsLog.Error($"Unable to activate macOS process {processId} via NSRunningApplication.", ex);
+        }
     }
 
     public static void SendPasteShortcut()
@@ -119,12 +140,68 @@ internal static class MacOSApplication
         if (!OperatingSystem.IsMacOS())
             return;
 
-        DiagnosticsLog.Info("Sending macOS paste shortcut via AppleScript.");
-        RunAppleScript("""
-            tell application "System Events"
-                keystroke "v" using command down
-            end tell
-            """);
+        DiagnosticsLog.Info("Sending macOS paste shortcut via CGEvent.");
+
+        try
+        {
+            const ushort kVK_ANSI_V = 0x09;
+            const ulong kCGEventFlagMaskCommand = 0x00100000;
+            const uint kCGHIDEventTap = 0;
+
+            IntPtr source = CoreGraphics.CGEventSourceCreate(1 /* kCGEventSourceStateHIDSystemState */);
+            try
+            {
+                IntPtr keyDown = CoreGraphics.CGEventCreateKeyboardEvent(source, kVK_ANSI_V, true);
+                IntPtr keyUp = CoreGraphics.CGEventCreateKeyboardEvent(source, kVK_ANSI_V, false);
+                try
+                {
+                    if (keyDown == IntPtr.Zero || keyUp == IntPtr.Zero)
+                    {
+                        DiagnosticsLog.Error("CGEventCreateKeyboardEvent returned null; cannot send paste shortcut.");
+                        return;
+                    }
+
+                    CoreGraphics.CGEventSetFlags(keyDown, kCGEventFlagMaskCommand);
+                    CoreGraphics.CGEventSetFlags(keyUp, kCGEventFlagMaskCommand);
+                    CoreGraphics.CGEventPost(kCGHIDEventTap, keyDown);
+                    CoreGraphics.CGEventPost(kCGHIDEventTap, keyUp);
+                }
+                finally
+                {
+                    if (keyDown != IntPtr.Zero) CoreGraphics.CFRelease(keyDown);
+                    if (keyUp != IntPtr.Zero) CoreGraphics.CFRelease(keyUp);
+                }
+            }
+            finally
+            {
+                if (source != IntPtr.Zero) CoreGraphics.CFRelease(source);
+            }
+        }
+        catch (Exception ex)
+        {
+            DiagnosticsLog.Error("Unable to send the macOS paste shortcut via CGEvent.", ex);
+        }
+    }
+
+    private static class CoreGraphics
+    {
+        private const string Framework = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
+        private const string CoreFoundation = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+
+        [DllImport(Framework)]
+        public static extern IntPtr CGEventSourceCreate(int stateID);
+
+        [DllImport(Framework)]
+        public static extern IntPtr CGEventCreateKeyboardEvent(IntPtr source, ushort virtualKey, [MarshalAs(UnmanagedType.I1)] bool keyDown);
+
+        [DllImport(Framework)]
+        public static extern void CGEventSetFlags(IntPtr @event, ulong flags);
+
+        [DllImport(Framework)]
+        public static extern void CGEventPost(uint tap, IntPtr @event);
+
+        [DllImport(CoreFoundation)]
+        public static extern void CFRelease(IntPtr cf);
     }
 
     private static class ObjC
@@ -142,6 +219,8 @@ internal static class MacOSApplication
         public static readonly IntPtr Sel_localizedName = sel_registerName("localizedName");
         public static readonly IntPtr Sel_bundleIdentifier = sel_registerName("bundleIdentifier");
         public static readonly IntPtr Sel_UTF8String = sel_registerName("UTF8String");
+        public static readonly IntPtr Sel_runningApplicationWithProcessIdentifier = sel_registerName("runningApplicationWithProcessIdentifier:");
+        public static readonly IntPtr Sel_activateWithOptions = sel_registerName("activateWithOptions:");
 
         [DllImport(LibSystem, CharSet = CharSet.Ansi)]
         private static extern IntPtr dlopen(string path, int mode);
@@ -156,7 +235,14 @@ internal static class MacOSApplication
         public static extern IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
 
         [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr IntPtr_IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
         public static extern int Int_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static extern bool Bool_ULong_objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg);
 
         public static string? ReadNSString(IntPtr nsString)
         {
@@ -169,43 +255,6 @@ internal static class MacOSApplication
 
             string? value = Marshal.PtrToStringUTF8(utf8);
             return string.IsNullOrEmpty(value) ? null : value;
-        }
-    }
-
-    private static string? RunAppleScript(string script)
-    {
-        try
-        {
-            using var process = new Process();
-            process.StartInfo = new ProcessStartInfo
-            {
-                FileName = "osascript",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            process.StartInfo.ArgumentList.Add("-e");
-            process.StartInfo.ArgumentList.Add(script);
-
-            process.Start();
-
-            string output = process.StandardOutput.ReadToEnd();
-            string error = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                DiagnosticsLog.Error($"AppleScript exited with code {process.ExitCode}: {error}");
-                return null;
-            }
-
-            return output.Trim();
-        }
-        catch (Exception ex)
-        {
-            DiagnosticsLog.Error("Unable to run AppleScript.", ex);
-            return null;
         }
     }
 }

--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Neptuo.Productivity.SnippetManager;
@@ -49,44 +50,48 @@ internal static class MacOSApplication
         if (!OperatingSystem.IsMacOS())
             return null;
 
-        string? output = RunAppleScript("""
-            tell application "System Events"
-                set p to first application process whose frontmost is true
-                set sep to (character id 31)
-                set n to ""
-                try
-                    set n to name of p
-                end try
-                set b to ""
-                try
-                    set b to bundle identifier of p
-                end try
-                return ((unix id of p) as string) & sep & n & sep & b
-            end tell
-            """);
-
-        if (string.IsNullOrEmpty(output))
+        try
         {
-            DiagnosticsLog.Error("Unable to resolve the frontmost macOS application (empty AppleScript output).");
+            IntPtr workspaceClass = ObjC.objc_getClass("NSWorkspace");
+            if (workspaceClass == IntPtr.Zero)
+            {
+                DiagnosticsLog.Error("Unable to resolve the NSWorkspace class via the Objective-C runtime.");
+                return null;
+            }
+
+            IntPtr sharedWorkspace = ObjC.IntPtr_objc_msgSend(workspaceClass, ObjC.Sel_sharedWorkspace);
+            if (sharedWorkspace == IntPtr.Zero)
+            {
+                DiagnosticsLog.Error("Unable to resolve [NSWorkspace sharedWorkspace].");
+                return null;
+            }
+
+            IntPtr frontApp = ObjC.IntPtr_objc_msgSend(sharedWorkspace, ObjC.Sel_frontmostApplication);
+            if (frontApp == IntPtr.Zero)
+            {
+                DiagnosticsLog.Error("Unable to resolve the frontmost macOS application (NSWorkspace returned nil).");
+                return null;
+            }
+
+            int processId = ObjC.Int_objc_msgSend(frontApp, ObjC.Sel_processIdentifier);
+            string? name = ObjC.ReadNSString(ObjC.IntPtr_objc_msgSend(frontApp, ObjC.Sel_localizedName));
+            string? bundle = ObjC.ReadNSString(ObjC.IntPtr_objc_msgSend(frontApp, ObjC.Sel_bundleIdentifier));
+
+            if (processId <= 0)
+            {
+                DiagnosticsLog.Error($"Frontmost macOS application returned a non-positive PID ({processId}).");
+                return null;
+            }
+
+            var app = new FrontmostApplication(processId, name, bundle);
+            DiagnosticsLog.Info($"Resolved the frontmost macOS application: {app.DescribeForLog()}.");
+            return app;
+        }
+        catch (Exception ex)
+        {
+            DiagnosticsLog.Error("Unable to resolve the frontmost macOS application via NSWorkspace.", ex);
             return null;
         }
-
-        string[] parts = output.Split(new[] { '\u001F' }, 3);
-        if (parts.Length == 0 || !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int processId))
-        {
-            DiagnosticsLog.Error($"Unable to parse the frontmost macOS application info from '{output}'.");
-            return null;
-        }
-
-        if (parts.Length < 3)
-            DiagnosticsLog.Error($"Frontmost macOS application info is missing fields (got {parts.Length}): '{output}'.");
-
-        string? name = parts.Length > 1 && !string.IsNullOrEmpty(parts[1]) ? parts[1] : null;
-        string? bundle = parts.Length > 2 && !string.IsNullOrEmpty(parts[2]) ? parts[2] : null;
-
-        var app = new FrontmostApplication(processId, name, bundle);
-        DiagnosticsLog.Info($"Resolved the frontmost macOS application: {app.DescribeForLog()}.");
-        return app;
     }
 
     public static void ActivateCurrentProcess()
@@ -120,6 +125,51 @@ internal static class MacOSApplication
                 keystroke "v" using command down
             end tell
             """);
+    }
+
+    private static class ObjC
+    {
+        private const string LibObjC = "/usr/lib/libobjc.dylib";
+        private const string LibSystem = "/usr/lib/libSystem.dylib";
+        private const string AppKitPath = "/System/Library/Frameworks/AppKit.framework/AppKit";
+
+        // Ensure AppKit is loaded so NSWorkspace is available. Idempotent; a no-op when Avalonia has already linked it.
+        private static readonly IntPtr AppKitHandle = dlopen(AppKitPath, 2 /* RTLD_NOW */);
+
+        public static readonly IntPtr Sel_sharedWorkspace = sel_registerName("sharedWorkspace");
+        public static readonly IntPtr Sel_frontmostApplication = sel_registerName("frontmostApplication");
+        public static readonly IntPtr Sel_processIdentifier = sel_registerName("processIdentifier");
+        public static readonly IntPtr Sel_localizedName = sel_registerName("localizedName");
+        public static readonly IntPtr Sel_bundleIdentifier = sel_registerName("bundleIdentifier");
+        public static readonly IntPtr Sel_UTF8String = sel_registerName("UTF8String");
+
+        [DllImport(LibSystem, CharSet = CharSet.Ansi)]
+        private static extern IntPtr dlopen(string path, int mode);
+
+        [DllImport(LibObjC, CharSet = CharSet.Ansi)]
+        public static extern IntPtr objc_getClass(string name);
+
+        [DllImport(LibObjC, CharSet = CharSet.Ansi)]
+        public static extern IntPtr sel_registerName(string name);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public static extern int Int_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        public static string? ReadNSString(IntPtr nsString)
+        {
+            if (nsString == IntPtr.Zero)
+                return null;
+
+            IntPtr utf8 = IntPtr_objc_msgSend(nsString, Sel_UTF8String);
+            if (utf8 == IntPtr.Zero)
+                return null;
+
+            string? value = Marshal.PtrToStringUTF8(utf8);
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
     }
 
     private static string? RunAppleScript(string script)


### PR DESCRIPTION
Every hotkey press previously spawned one or more `osascript` processes to read the frontmost app, reactivate the previous app, and send Cmd+V. Each AppleScript invocation fork/execs a shell and spins up the AppleScript runtime (tens to hundreds of milliseconds), which is noticeable on the hot path from hotkey to paste.

This PR replaces all three AppleScript calls with direct in-process macOS APIs:

- `GetFrontmostApplication` now calls `[NSWorkspace sharedWorkspace].frontmostApplication` through the Objective-C runtime (`objc_msgSend`), reading `processIdentifier`, `localizedName`, and `bundleIdentifier` directly. AppKit is `dlopen`ed defensively on first use so the call works regardless of initialization order (it is a no-op when Avalonia has already linked it).
- `ActivateProcess` uses `NSRunningApplication.runningApplicationWithProcessIdentifier:` + `activateWithOptions:` with `NSApplicationActivateIgnoringOtherApps`.
- `SendPasteShortcut` posts a synthetic Cmd+V via `CGEventCreateKeyboardEvent` and `CGEventPost`, with `CFRelease` on all Create-rule objects.

The now-unused `RunAppleScript` helper is removed.

### Notes for reviewers

- Classic `DllImport` is used rather than `LibraryImport` to avoid enabling `AllowUnsafeBlocks` project-wide (the source generator for `LibraryImport` requires it).
- `CGEventPost` needs the same Accessibility/Input Monitoring permission the AppleScript `keystroke` path already required, so users with existing permissions are unaffected. `NSRunningApplication.activateWithOptions:` actually relaxes one requirement: the old path also needed System Events automation permission, which is no longer used.
- Smoke-tested the NSWorkspace lookup against a live process and confirmed it returns the correct pid/name/bundle. Build is green and all 110 tests pass.