### PR TITLE
Add github.dev (VS Code Online) snippet per repository

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.GitHub/GitHubSnippetProvider.cs
+++ b/src/Neptuo.Productivity.SnippetManager.GitHub/GitHubSnippetProvider.cs
@@ -198,5 +198,11 @@ public class GitHubSnippetProvider(GitHubConfiguration configuration) : SingleIn
             text: $"{htmlUrl}/activity?actor={configuration.UserName}",
             priority: SnippetPriority.Low
         ));
+
+        snippets.Add(new SnippetModel(
+            title: $"{repositoryTitle} - VS Code Online",
+            text: $"https://github.dev/{owner}/{repository}",
+            priority: SnippetPriority.Low
+        ));
     }
 }


### PR DESCRIPTION
Closes #112

Adds a quick jump into the web-based VS Code editor for every GitHub repository surfaced by the provider, so users can open a repo in github.dev without manually rewriting the URL.

## Approach

Extend `GitHubSnippetProvider.AddSnippetsForRepository` with one additional low-priority `SnippetModel`:

- Title: `{repositoryTitle} - VS Code Online`
- URL: `https://github.dev/{owner}/{repository}`

Because every repository source (user repos, organization repos, starred repos, and `ExtraRepositories`) funnels through `AddSnippetsForRepository`, the new snippet is emitted uniformly with no changes to the individual code paths or configuration.

## Notes

- No new configuration flag: the link applies to any GitHub repo and has no runtime cost.
- Title wording matches the issue phrasing ("vscode online") and sits alongside the existing sub-entries (Issues, Pulls, Find file, Code search, My activity).