### PR TITLE
Clear modifier flags on synthetic Enter on macOS

### DIFF
--- a/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
+++ b/src/Neptuo.Productivity.SnippetManager.Avalonia/MacOSApplication.cs
@@ -211,6 +211,12 @@ internal static class MacOSApplication
                         return;
                     }
 
+                    // Explicitly clear modifier flags so the synthetic Return is not
+                    // interpreted as Cmd+Enter (e.g., Edge would otherwise open a new
+                    // tab because the preceding Cmd+V events left Cmd flagged, or the
+                    // HID system still sees Cmd physically held).
+                    CoreGraphics.CGEventSetFlags(keyDown, 0);
+                    CoreGraphics.CGEventSetFlags(keyUp, 0);
                     CoreGraphics.CGEventPost(kCGHIDEventTap, keyDown);
                     CoreGraphics.CGEventPost(kCGHIDEventTap, keyUp);
                 }


### PR DESCRIPTION
When auto-submitting a snippet with Cmd+Enter on macOS, the target app (e.g., Edge) would often see Cmd+Enter instead of plain Enter — for example, pasting a URL snippet into the address bar would open a new tab rather than just navigate in the current one.

## Cause

`MacOSApplication.SendEnterShortcut` created the Return `CGEvent` without ever calling `CGEventSetFlags`. The event source (`kCGEventSourceStateHIDSystemState`) inherits the current modifier state, and the preceding synthetic Cmd+V posted both keyDown and keyUp for `V` with the Cmd flag set, which leaves Cmd latched in the session state. The Return event then went out carrying Cmd.

## Fix

Explicitly set `flags = 0` on both the keyDown and keyUp Return events in `SendEnterShortcut`, so the synthetic Enter is delivered as a plain Enter regardless of any stale Cmd state from the paste or a physically still-held Cmd key.

Note: I also considered re-awaiting `WaitForAutoSubmitModifierReleaseAsync()` right before `SimulateEnter`, but that ended up waiting indefinitely (or until the user physically tapped Cmd again) because our own Cmd+V injection keeps Cmd reported as pressed in the combined session state. Clearing the flags on the Return event itself is the right layer to solve this.